### PR TITLE
Add ability to pass connectivity options to gRPC client code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = caller
  *                              Object specifying <code>root</code> directory and <code>file</code> to load or
  *                              the static client constructor object itself
  * @param {String} name - In case of proto path the name of the service as defined in the proto definition.
+ * @param {Object} credentials - The credentials to use to connect. Defaults to `grpc.credentials.createInsecure()`
  * @param {Object} options - Options to be passed to the gRPC client constructor
  * @param {Object} options.retry - In addition to gRPC client constructor options, we accept a `retry` option.
  *                                 The retry option is identical to `async.retry` and is passed as is to it.
@@ -34,7 +35,7 @@ module.exports = caller
  * const services = require('./static/helloworld_grpc_pb')
  * const client = caller('localhost:50051', services.GreeterClient)
  */
-function caller (host, proto, name, options) {
+function caller (host, proto, name, credentials, options) {
   let Ctor
   if (_.isString(proto) || (_.isObject(proto) && proto.root && proto.file)) {
     const loaded = grpc.load(proto)
@@ -49,10 +50,11 @@ function caller (host, proto, name, options) {
     }
   } else if (_.isObject(proto)) {
     Ctor = proto
-    options = name
+    options = credentials
+    credentials = name
   }
 
-  const client = new Ctor(host, options || grpc.credentials.createInsecure())
+  const client = new Ctor(host, credentials || grpc.credentials.createInsecure(), options)
 
   return wrap(client)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olono/grpc-caller",
+  "name": "grpc-caller",
   "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "grpc-caller",
-  "version": "0.5.0",
+  "name": "@olono/grpc-caller",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "grpc-caller",
-  "version": "0.5.0",
+  "name": "@olono/grpc-caller",
+  "version": "0.6.0",
   "description": "An improved Node.js gRPC client",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olono/grpc-caller",
+  "name": "grpc-caller",
   "version": "0.6.0",
   "description": "An improved Node.js gRPC client",
   "main": "lib/index.js",


### PR DESCRIPTION
The current `options` argument is really the `credentials` argument passed to the gRPC client code. We need the ability to also pass in connectivity options, to control things like load balancing policy and client-side keep alive policy.